### PR TITLE
fix: setup port to python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,5 +76,4 @@ setup(
                  'Topic :: Games/Entertainment'],
     test_suite='elotests',
     tests_require=['pytest', 'almost'],
-    use_2to3=(sys.version_info[0] >= 3),
 )


### PR DESCRIPTION
use2_to3 disappeared on python3